### PR TITLE
Avoid creating needless slices of IPs (fixes #6)

### DIFF
--- a/example_middleware_test.go
+++ b/example_middleware_test.go
@@ -3,7 +3,7 @@ package realclientip_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -32,7 +32,7 @@ func Example_middleware() {
 		log.Fatal(err)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/realclientip/realclientip-go
 
-go 1.13
+go 1.23.0

--- a/realclientip_test.go
+++ b/realclientip_test.go
@@ -2034,7 +2034,11 @@ func Test_forwardedHeaderRFCDeviations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getIPAddrList(tt.args.headers, tt.args.headerName); !reflect.DeepEqual(got, tt.want) {
+			var got []*net.IPAddr
+			for ip := range allIPAddrFromFirstToLast(tt.args.headers, tt.args.headerName) {
+				got = append(got, ip)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getIPAddrList() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
This PR requires Go 1.23 or above.

I haven't written any benchmarks (to compare before and after) this change, but I expect at least a drop in the amount of allocations.