### PR TITLE
Fix RFC 2544 private-range typo: 192.18.0.0/15 -> 198.18.0.0/15

### DIFF
--- a/realclientip.go
+++ b/realclientip.go
@@ -648,7 +648,7 @@ var privateAndLocalRanges = []net.IPNet{
 	mustParseCIDR("198.51.100.0/24"),    // Assigned as TEST-NET-2
 	mustParseCIDR("203.0.113.0/24"),     // Assigned as TEST-NET-3
 	mustParseCIDR("192.88.99.0/24"),     // RFC 3068
-	mustParseCIDR("192.18.0.0/15"),      // RFC 2544
+	mustParseCIDR("198.18.0.0/15"),      // RFC 2544
 	mustParseCIDR("224.0.0.0/4"),        // RFC 3171
 	mustParseCIDR("240.0.0.0/4"),        // RFC 1112
 	mustParseCIDR("255.255.255.255/32"), // RFC 919 Section 7

--- a/realclientip_test.go
+++ b/realclientip_test.go
@@ -1683,6 +1683,19 @@ func Test_isPrivateOrLocal(t *testing.T) {
 			ip:   `::ffff:188.0.2.128`,
 			want: false,
 		},
+		{
+			// RFC 2544 benchmarking range is 198.18.0.0/15.
+			name: "IPv4 RFC 2544 benchmarking",
+			ip:   `198.18.5.5`,
+			want: true,
+		},
+		{
+			// 192.18.0.0/15 is routable public space, not a reserved range.
+			// Guards against the 198.18/192.18 typo (see issue #8).
+			name: "IPv4 192.18.0.0/15 is public",
+			ip:   `192.18.5.5`,
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## What

Corrects a typo in the private/local range list: `192.18.0.0/15` → `198.18.0.0/15` (RFC 2544 benchmarking range), and adds RFC-anchored test cases.

## Why

`192.18.0.0/15` is routable, allocated public address space; the intended RFC 2544 range is `198.18.0.0/15`. The typo corrupted `isPrivateOrLocal` (used by `LeftmostNonPrivateStrategy` / `RightmostNonPrivateStrategy`) in both directions:

- **False positive:** a genuine public client in `192.18.0.0/15` was treated as private and skipped, causing client-IP misattribution.
- **False negative:** the actual benchmarking range `198.18.0.0/15` was treated as a valid public client IP.

The trusted-count / trusted-range strategies are unaffected.

## Tests

Added two cases to `Test_isPrivateOrLocal` that validate the list against the RFC rather than against itself:

- `198.18.5.5` expects private (would have failed before this fix)
- `192.18.5.5` expects public (would have failed before this fix)

Full suite passes.

Fixes #8
