### PR TITLE
RightmostTrustedRangeStrategy: verify the connecting peer (remoteAddr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Do not abuse `ChainStrategy` to check multiple headers. There is likely only one
 
 [single-ip-wiki]: https://github.com/realclientip/realclientip-go/wiki/Single-IP-Headers
 
+### Servers reachable both directly and via a proxy
+
+If your server can be reached *both* through your reverse proxy *and* directly from the internet, a header-based strategy can be tricked: an attacker connecting directly can send a forged `X-Forwarded-For`/`Forwarded` header. The defense is to confirm the connecting peer (`remoteAddr`) is actually one of your proxies before trusting the header.
+
+`RightmostTrustedRangeStrategy` does this for you. It checks `remoteAddr` against its trusted ranges; if the peer is a valid IP that isn't trusted, the request didn't arrive through a proxy, so the header is ignored and the (unspoofable) peer is returned. A non-IP peer such as a Unix-domain socket is treated as local and the header is honored. The other strategies don't have the trusted-range information to do this, so if you use them in a directly-reachable deployment you must verify `remoteAddr` belongs to a trusted proxy yourself.
+
 #### `Forwarded` header support
 
 Support for the [`Forwarded` header] should be sufficient for the vast majority of rightmost-ish uses, but it is not complete and doesn't completely adhere  to [RFC 7239]. See the [`Test_forwardedHeaderRFCDeviations`] test for details on deviations.

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -56,32 +56,34 @@ func Fuzz_parseForwardedListItem(f *testing.F) {
 	})
 }
 
-// Fuzz_ClientIP_XFF feeds arbitrary X-Forwarded-For header values through the
-// XFF-based strategies and checks invariants that are independent of how the
-// strategies compute their answer -- genuine oracles rather than a
-// reimplementation of the walk:
+// Fuzz_ClientIP_XFF feeds arbitrary X-Forwarded-For header values and arbitrary
+// remoteAddr values through the XFF-based strategies and checks invariants that
+// are independent of how the strategies compute their answer -- genuine oracles
+// rather than a reimplementation of the walk:
 //
 //   - Any non-empty result is a valid IP that round-trips: re-parsing and
 //     re-stringifying it yields the identical string (the library promises
 //     normalized, canonical output).
-//   - Feeding a non-empty result straight back in as the whole header yields
-//     the same result (idempotence of the full strategy).
+//   - Feeding a non-empty result back in as the whole header, with the same
+//     remoteAddr, yields the same result (idempotence of the full strategy).
 //   - LeftmostNonPrivate / RightmostNonPrivate never return a private/local IP.
-//   - RightmostTrustedRange never returns an IP inside a trusted range.
+//   - RightmostTrustedRange never returns an IP inside a trusted range -- which
+//     must hold whether the result came from the header or from the verified
+//     peer (remoteAddr).
 func Fuzz_ClientIP_XFF(f *testing.F) {
-	seeds := []string{
-		"1.1.1.1",
-		"1.1.1.1, 2.2.2.2",
-		"10.0.0.1, 192.168.1.1, 3.3.3.3",
-		"::1, 2607:f8b0:4004:83f::200e",
-		"  fe80::1%eth0 , 4.4.4.4 ",
-		"not-an-ip, 5.5.5.5",
-		"1.1.1.1,,2.2.2.2",
-		"::ffff:188.0.2.128",
-		"",
+	seeds := []struct{ xff, remoteAddr string }{
+		{"1.1.1.1", ""},
+		{"1.1.1.1, 2.2.2.2", "10.0.0.1:80"},                // trusted peer
+		{"10.0.0.1, 192.168.1.1, 3.3.3.3", "9.9.9.9:1234"}, // untrusted peer
+		{"::1, 2607:f8b0:4004:83f::200e", "@"},             // Unix-socket peer
+		{"  fe80::1%eth0 , 4.4.4.4 ", "[fe80::1%eth0]:9"},
+		{"not-an-ip, 5.5.5.5", "ohno"}, // unparseable peer
+		{"1.1.1.1,,2.2.2.2", "[2607:f8b0::1]:443"},
+		{"::ffff:188.0.2.128", "192.168.1.1:5"},
+		{"", "9.9.9.9"},
 	}
 	for _, s := range seeds {
-		f.Add(s)
+		f.Add(s.xff, s.remoteAddr)
 	}
 
 	trustedRanges, err := AddressesAndRangesToIPNets("10.0.0.0/8", "192.168.0.0/16", "fc00::/7")
@@ -113,9 +115,9 @@ func Fuzz_ClientIP_XFF(f *testing.F) {
 		{trusted, func(ip net.IP) bool { return !isIPContainedInRanges(ip, trustedRanges) }, "outside-trusted-ranges"},
 	}
 
-	f.Fuzz(func(t *testing.T, xff string) {
+	f.Fuzz(func(t *testing.T, xff, remoteAddr string) {
 		for _, c := range cases {
-			result := c.strat.ClientIP(http.Header{xForwardedForHdr: []string{xff}}, "")
+			result := c.strat.ClientIP(http.Header{xForwardedForHdr: []string{xff}}, remoteAddr)
 			if result == "" {
 				continue
 			}
@@ -123,21 +125,24 @@ func Fuzz_ClientIP_XFF(f *testing.F) {
 			// Must be a valid, canonical IP.
 			ipAddr, err := ParseIPAddr(result)
 			if err != nil {
-				t.Fatalf("%T returned unparseable %q from XFF %q", c.strat, result, xff)
+				t.Fatalf("%T returned unparseable %q from XFF %q remoteAddr %q", c.strat, result, xff, remoteAddr)
 			}
 			if ipAddr.String() != result {
 				t.Fatalf("%T result %q is not canonical (re-stringifies to %q)", c.strat, result, ipAddr.String())
 			}
 
-			// Post-condition for this strategy.
+			// Post-condition for this strategy. For RightmostTrustedRange this also
+			// covers the peer path: whether the result comes from remoteAddr or from
+			// the header, it must still be outside the trusted ranges.
 			if !c.postcond(ipAddr.IP) {
-				t.Fatalf("%T result %q violates %s (XFF %q)", c.strat, result, c.condName, xff)
+				t.Fatalf("%T result %q violates %s (XFF %q remoteAddr %q)", c.strat, result, c.condName, xff, remoteAddr)
 			}
 
-			// Idempotence: feeding the result back as the whole header yields it.
-			back := c.strat.ClientIP(http.Header{xForwardedForHdr: []string{result}}, "")
+			// Idempotence: feeding the result back as the whole header, with the same
+			// remoteAddr, yields it.
+			back := c.strat.ClientIP(http.Header{xForwardedForHdr: []string{result}}, remoteAddr)
 			if back != result {
-				t.Fatalf("%T not idempotent: %q -> %q", c.strat, result, back)
+				t.Fatalf("%T not idempotent: %q -> %q (remoteAddr %q)", c.strat, result, back, remoteAddr)
 			}
 		}
 	})

--- a/realclientip.go
+++ b/realclientip.go
@@ -358,6 +358,14 @@ func AddressesAndRangesToIPNets(ranges ...string) ([]net.IPNet, error) {
 // in the X-Forwarded-For or Forwarded header which is not in a set of trusted IP ranges.
 // This strategy should be used when the IP ranges of the reverse proxies between the
 // internet and the server are known.
+//
+// This strategy also verifies the connecting peer (remoteAddr): if the peer is a valid IP
+// that is not in the trusted ranges, the request did not arrive through a trusted proxy,
+// the header is untrustworthy, and the peer itself is returned. This makes the strategy
+// safe to use on a server that is reachable both through a trusted proxy and directly (an
+// attacker connecting directly cannot spoof the client IP via a forged header). See
+// ClientIP for the exact peer-handling rules.
+//
 // If a third-party WAF, CDN, etc., is used, you SHOULD use a method of verifying its
 // access to your origin that is stronger than checking its IP address (e.g., using
 // authenticated pulls). Failure to do so can result in scenarios like:
@@ -392,9 +400,32 @@ func NewRightmostTrustedRangeStrategy(headerName string, trustedRanges []net.IPN
 
 // ClientIP derives the client IP using this strategy.
 // headers is expected to be like http.Request.Header.
+// remoteAddr is expected to be like http.Request.RemoteAddr.
 // The returned IP may contain a zone identifier.
 // If no valid IP can be derived, empty string will be returned.
-func (strat RightmostTrustedRangeStrategy) ClientIP(headers http.Header, _ string) string {
+//
+// The connecting peer (remoteAddr) is checked first:
+//   - If remoteAddr is a valid IP that is NOT in the trusted ranges, the request did not
+//     arrive through a trusted proxy. The header cannot be trusted, so it is ignored and
+//     remoteAddr is returned (it is the rightmost untrusted address). This both defeats
+//     header spoofing by a directly-connecting attacker and yields the correct IP for a
+//     legitimate client connecting directly.
+//   - If remoteAddr is a valid IP that IS in the trusted ranges, it is a trusted proxy and
+//     the header is walked as normal.
+//   - If remoteAddr is not a usable IP (empty, a Unix-domain-socket peer like "@", or
+//     otherwise unparseable), the peer cannot be classified and the header is walked as
+//     normal. This keeps legitimate local-socket topologies working (for example,
+//     client -> CDN -> nginx -(unix socket)-> app); a Unix socket is unreachable from the
+//     network and so cannot be a spoofing vector. To get peer verification, pass a real
+//     remoteAddr (as http.Request.RemoteAddr always provides for network connections).
+func (strat RightmostTrustedRangeStrategy) ClientIP(headers http.Header, remoteAddr string) string {
+	// If the connecting peer is a valid IP outside our trusted ranges, the request did not
+	// come through a trusted proxy; the header is untrustworthy and the peer is the
+	// rightmost untrusted address, so return it.
+	if peer := goodIPAddr(remoteAddr); peer != nil && !isIPContainedInRanges(peer.IP, strat.trustedRanges) {
+		return peer.String()
+	}
+
 	ipAddrs := getIPAddrList(headers, strat.headerName)
 	// Look backwards through the list of IP addresses
 	for i := len(ipAddrs) - 1; i >= 0; i-- {

--- a/realclientip_test.go
+++ b/realclientip_test.go
@@ -1277,6 +1277,112 @@ func TestRightmostTrustedRangeStrategy(t *testing.T) {
 			want: "4.4.4.4",
 		},
 		{
+			// Peer is a valid IP outside the trusted ranges: the request did not
+			// arrive through a trusted proxy, so the (spoofed) header is ignored and
+			// the peer is returned -- NOT the victim the header tries to inject.
+			name: "Peer untrusted: returns peer, ignores spoofed header",
+			args: args{
+				headerName: "X-Forwarded-For",
+				headers: http.Header{
+					"X-Forwarded-For": []string{`1.2.3.4, 10.0.0.1`},
+				},
+				remoteAddr:    "9.9.9.9:1234",
+				trustedRanges: []string{`10.0.0.0/8`},
+			},
+			want: "9.9.9.9",
+		},
+		{
+			// The direct-client case from issue #4: untrusted peer, no header.
+			name: "Peer untrusted, no header: returns peer",
+			args: args{
+				headerName: "X-Forwarded-For",
+				headers: http.Header{
+					"X-Forwarded-For": []string{},
+				},
+				remoteAddr:    "9.9.9.9",
+				trustedRanges: []string{`10.0.0.0/8`},
+			},
+			want: "9.9.9.9",
+		},
+		{
+			// Untrusted IPv6 peer with a zone is returned canonically, zone retained.
+			name: "Peer untrusted IPv6 with zone: returns peer with zone",
+			args: args{
+				headerName: "X-Forwarded-For",
+				headers: http.Header{
+					"X-Forwarded-For": []string{`1.2.3.4`},
+				},
+				remoteAddr:    "[fe80::1%eth0]:9999",
+				trustedRanges: []string{`10.0.0.0/8`},
+			},
+			want: "fe80::1%eth0",
+		},
+		{
+			// Trusted peer: behaves exactly as the header-only walk (regression guard
+			// that normal proxy deployments are unaffected by peer verification).
+			name: "Peer trusted: walks header as normal",
+			args: args{
+				headerName: "X-Forwarded-For",
+				headers: http.Header{
+					"X-Forwarded-For": []string{`3.3.3.3, 10.0.0.1`},
+				},
+				remoteAddr:    "10.0.0.5:555",
+				trustedRanges: []string{`10.0.0.0/8`},
+			},
+			want: "3.3.3.3",
+		},
+		{
+			// Unix-domain-socket peer ("@") is not an IP; fall through to the header.
+			name: "Peer Unix socket: walks header as normal",
+			args: args{
+				headerName: "X-Forwarded-For",
+				headers: http.Header{
+					"X-Forwarded-For": []string{`3.3.3.3, 10.0.0.1`},
+				},
+				remoteAddr:    "@",
+				trustedRanges: []string{`10.0.0.0/8`},
+			},
+			want: "3.3.3.3",
+		},
+		{
+			name: "Peer empty: walks header as normal",
+			args: args{
+				headerName: "X-Forwarded-For",
+				headers: http.Header{
+					"X-Forwarded-For": []string{`3.3.3.3, 10.0.0.1`},
+				},
+				remoteAddr:    "",
+				trustedRanges: []string{`10.0.0.0/8`},
+			},
+			want: "3.3.3.3",
+		},
+		{
+			name: "Peer garbage: walks header as normal",
+			args: args{
+				headerName: "X-Forwarded-For",
+				headers: http.Header{
+					"X-Forwarded-For": []string{`3.3.3.3, 10.0.0.1`},
+				},
+				remoteAddr:    "ohno",
+				trustedRanges: []string{`10.0.0.0/8`},
+			},
+			want: "3.3.3.3",
+		},
+		{
+			// Unspecified peer IP (0.0.0.0) is rejected by goodIPAddr, so we cannot
+			// classify it and fall through to the header.
+			name: "Peer unspecified IP: walks header as normal",
+			args: args{
+				headerName: "X-Forwarded-For",
+				headers: http.Header{
+					"X-Forwarded-For": []string{`3.3.3.3, 10.0.0.1`},
+				},
+				remoteAddr:    "0.0.0.0",
+				trustedRanges: []string{`10.0.0.0/8`},
+			},
+			want: "3.3.3.3",
+		},
+		{
 			name: "Fail: no non-trusted IP",
 			args: args{
 				headerName: "X-Forwarded-For",

--- a/testdata/fuzz/Fuzz_ClientIP_XFF/98de4cfc88e65072
+++ b/testdata/fuzz/Fuzz_ClientIP_XFF/98de4cfc88e65072
@@ -1,2 +1,3 @@
 go test fuzz v1
 string("0.0.0.1% :")
+string("")

--- a/testdata/fuzz/Fuzz_ClientIP_XFF/e4d008e50955e950
+++ b/testdata/fuzz/Fuzz_ClientIP_XFF/e4d008e50955e950
@@ -1,2 +1,3 @@
 go test fuzz v1
 string("::fffF:0:1%:")
+string("")


### PR DESCRIPTION
Closes the dual-connectable spoofing gap for `RightmostTrustedRangeStrategy` (the underlying concern in #4).

## Problem

The strategy decided the client IP purely from the header and ignored `remoteAddr` (it took `_ string`). On a server reachable **both** through a trusted proxy **and** directly, an attacker connecting directly could send a forged `X-Forwarded-For` / `Forwarded` header — e.g. `victim, <ip-in-a-trusted-range>` — and the strategy would skip the trusted entry and return `victim`. Full client-IP spoof. This is exactly the attack the project's own [blog post](https://adam-p.ca/blog/2022/03/x-forwarded-for/) warns about, whose mitigation is "verify `RemoteAddr` is your proxy before trusting XFF."

## Fix

The strategy now classifies the connecting peer (`remoteAddr`) before walking the header:

- **untrusted IP peer** → the request didn't arrive through a trusted proxy, so the header is untrustworthy and ignored; the peer (the real, unspoofable address) is returned. This also yields the correct IP for a *legitimate* client connecting directly — #4's valid use case, for free.
- **trusted IP peer** → walk the header as before (normal proxy path, unchanged).
- **non-IP / empty / unspecified peer** → can't classify; fall through to the header. This keeps legitimate local-socket topologies working (`client → CDN → nginx →(unix socket)→ app`); a Unix socket is unreachable from the network, so it can't be a spoofing vector.

### Why this is secure-by-default and not a breaking change in practice

In a correctly-configured proxy-only deployment, `remoteAddr` is always a trusted proxy, so it's skipped and the result is **identical** to before. Behavior only diverges in the attack/misconfig path. The canonical call `strategy.ClientIP(req.Header, req.RemoteAddr)` already passes the peer, so existing users get the protection automatically.

Evidence: every existing case in `TestRightmostTrustedRangeStrategy` used `remoteAddr=""` and still passes unchanged; the change is purely additive to the test suite.

## Tests & fuzzing

- New `TestRightmostTrustedRangeStrategy` cases: untrusted peer returns the peer (and **not** the spoofed header value), untrusted IPv6 peer with zone retained, trusted peer = header-only (regression guard), and `@`/empty/garbage/`0.0.0.0` peers falling through.
- Extended `Fuzz_ClientIP_XFF` to fuzz `remoteAddr` as well, so the "RightmostTrustedRange never returns an IP inside a trusted range" oracle now also covers the peer path. The two committed regression seeds were migrated to the new two-argument arity. 20s/~580k-exec smoke run is clean.

## Scope

This deliberately does **not** touch `RightmostTrustedCountStrategy` or `SingleIPHeaderStrategy`, which share the gap but structurally lack the trusted-range information to self-verify. They need a separate, additive peer-gate construct and are tracked separately.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l` (clean), `go test ./...` all pass.
